### PR TITLE
Fix label positions 

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -988,7 +988,6 @@ function! s:PromptUser(groups) "{{{
 
     let coord_key_dict = s:CreateCoordKeyDict(a:groups)
 
-    let prev_col_num = 0
     for dict_key in sort(coord_key_dict[0])
         " NOTE: {{{
         " let g:EasyMotion_keys = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -1022,19 +1021,14 @@ function! s:PromptUser(groups) "{{{
         let line_num = str2nr(line_num)
         let col_num = str2nr(col_num)
 
-        let col_num = col_num + 1
-        let prev_col_num = col_num
-
         if _hl_group == g:EasyMotion_hl_group_target && ! has_key(lines, line_num)
             let lines[line_num] = [[col_num, marker_chars]]
-            let prev_col_num = 0
         elseif _hl_group == g:EasyMotion_hl_group_target
             call add(lines[line_num], [col_num, marker_chars])
         endif
 
         if _hl_group == g:EasyMotion_hl2_first_group_target && ! has_key(lines2, line_num)
             let lines2[line_num] = [[col_num, marker_chars]]
-            let prev_col_num = 0
         elseif _hl_group == g:EasyMotion_hl2_first_group_target
             call add(lines2[line_num], [col_num, marker_chars])
         endif

--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1022,7 +1022,7 @@ function! s:PromptUser(groups) "{{{
         let line_num = str2nr(line_num)
         let col_num = str2nr(col_num)
 
-        let col_num = max([prev_col_num + 1, col_num])
+        let col_num = col_num + 1
         let prev_col_num = col_num
 
         if _hl_group == g:EasyMotion_hl_group_target && ! has_key(lines, line_num)


### PR DESCRIPTION
Fixes [#60](https://github.com/asvetliakov/vscode-neovim/issues/60)

This needs to be tested though. You can install my branch with the following line:
```
Plug 'https://github.com/bogdan0083/vim-easymotion.git', { 'branch': 'fix/label-position' }
```

The problem was in the expression `max([prev_col_num + 1, col_num])`. If previous column number was higher then current column number then label was placed to the end of the line, which is not a correct behavior.